### PR TITLE
Fix erroneous check for __attribute__ definition

### DIFF
--- a/apr/include/apr.h.in
+++ b/apr/include/apr.h.in
@@ -64,11 +64,7 @@
 #else  /* !__GNUC__ */
 #define APR_INLINE
 #define APR_HAS_INLINE          0
-/* __has_attribute should always be a pre-defined macro, but not
- * necessarily __attribute__ (e.g. builtin), so check for both to
- * avoid overriding __attribute__.
- */
-#if !(defined(__attribute__) || defined(__has_attribute))
+#if !defined(__attribute__)
 #define __attribute__(__x)
 #endif
 #endif /* !__GNUC__ */

--- a/apr/include/apr.hw
+++ b/apr/include/apr.hw
@@ -149,11 +149,7 @@
 #define APR_INLINE
 #define APR_HAS_INLINE          0
 #endif /* !_MSC_VER */
-/* __has_attribute should always be a pre-defined macro, but not
- * necessarily __attribute__ (e.g. builtin), so check for both to
- * avoid overriding __attribute__.
- */
-#if !(defined(__attribute__) || defined(__has_attribute))
+#if !defined(__attribute__)
 #define __attribute__(__x)
 #endif
 #endif /* !__GNUC__ */

--- a/apr/include/apr.hwc
+++ b/apr/include/apr.hwc
@@ -136,11 +136,7 @@
 #define APR_INLINE
 #define APR_HAS_INLINE          0
 #endif /* !_MSC_VER */
-/* __has_attribute should always be a pre-defined macro, but not
- * necessarily __attribute__ (e.g. builtin), so check for both to
- * avoid overriding __attribute__.
- */
-#if !(defined(__attribute__) || defined(__has_attribute))
+#if !defined(__attribute__)
 #define __attribute__(__x)
 #endif
 #endif /* !__GNUC__ */


### PR DESCRIPTION
Properly fixes the issue the cmake patch is trying to fix here- https://github.com/secondlife/viewer/pull/4828
Also fixes the full rebuild issue introduced because of that commit- https://github.com/secondlife/viewer/issues/4860